### PR TITLE
Fix Couchdb service script enabling

### DIFF
--- a/src/install/manual.md
+++ b/src/install/manual.md
@@ -80,6 +80,9 @@ Type=simple
 User=couchdb
 ExecStart=/home/couchdb/bin/couchdb -o /dev/stdout -e /dev/stderr
 Restart=always
+
+[Install]
+WantedBy=multi-user.target
 EOT
 ```
 


### PR DESCRIPTION
The command `systemctl enable couchdb.service`" failed with this message :

> The unit files have no [Install] section. They are not meant to be enabled
> using systemctl.
> Possible reasons for having this kind of units are:
> 1) A unit may be statically enabled by being symlinked from another unit's
>    .wants/ or .requires/ directory.
> 2) A unit's purpose may be to act as a helper for some other unit which has
>    a requirement dependency on it.
> 3) A unit may be started when needed via activation (socket, path, timer,
>    D-Bus, udev, scripted systemctl call, ...).
