### PR TITLE
Fix some broken URLs and missing translation

### DIFF
--- a/src/index_fr.md
+++ b/src/index_fr.md
@@ -1,34 +1,34 @@
-# Cozy Documentation
+# Documentation Cozy
 
-The go-to website about Cozy configuration and setup.
+Tout ce qu’il faut savoir pour utiliser et configurer Cozy.
 
 <div class="home-actions" markdown="1">
 
   <div class="home-action">
     <div>
-      <a href="use/"><img src="../assets/images/home/icon-cloud.svg">
+      <a href="../use/index_fr"><img src="../assets/images/home/icon-cloud.svg">
       [Découverte de votre nouveau domicile numérique](use/index_fr)
     </div>
   </div>
 
   <div class="home-action">
     <div>
-      <a href="sync/"><img src="../assets/images/home/icon-phone.svg"></a>
+      <a href="../sync/"><img src="../assets/images/home/icon-phone.svg"></a>
       [Synchronisez toutes vos données](sync)
     </div>
   </div>
 
   <div class="home-action">
     <div>
-      <a href="install/"><img src="../assets/images/home/icon-install.svg">
+      <a href="../install/"><img src="../assets/images/home/icon-install.svg">
       [Installez votre propre serveur](install)
     </div>
   </div>
 
   <div class="home-action">
     <div>
-      <a href="dev/"><img src="../assets/images/home/icon-dev.svg"></a>
-      [Développez !](dev)
+      <a href="../dev/"><img src="../assets/images/home/icon-dev.svg"></a>
+      [Développez !](dev)
       Apprenez à développer des applications et des connecteurs.
     </div>
   </div>
@@ -36,10 +36,11 @@ The go-to website about Cozy configuration and setup.
 
 </div>
 
-## Get in touch
+## Restons en contact
 
-If you have any questions, you can contact us via these 3 medias:
+Si vous avez des questions, 3 options s’offrent à vous :
 
- - write an email to our Support team: contact at cozy.io;
- - [post on the forum](https://forum.cozy.io/);
- - [chat with us on IRC](https://forum.cozy.io/);
+
+ - [envoyer un courriel à notre équipe d’assistance : contact@cozycloud.cc](mailto:contact@cozycloud.cc);
+ - [créer un nouveau sujet sur le forum](https://forum.cozy.io/);
+ - [discuter avec nous sur IRC](https://webchat.freenode.net/?channels=cozycloud);


### PR DESCRIPTION
Several URLs are broken in FR page. Care, I don't know how the doc is built hence, how the corrected links will be rendered...
Curiously, some sentences are not translated in FR in this source file, contrary to the online docs. I've missed smthg... but here is the correct FR translation.