### PR TITLE
feat: include other docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 i18n/fr_FR/LC_MESSAGES/messages.mo
 i18n/fr_FR/LC_MESSAGES/messages.po~
 .venv
+src/cozy-konnector-libs
+src/cozy-client-js

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,19 @@
+language: python
+python:
+- '2.7'
+git:
+  depth: 1
+env:
+  global:
+  - secure: el/25x4Vh2BiDCS8i5n1qb2TSHWKhlHKHZV8oZklzZZqlVywy4RjoxH3oP+u+84NDQmsN/PH0RMf3zLdpmyuy6ViCx90J4GcoNuvnd+m0T6NEgoDmLbCATlEHBd60GrCPhudCgdFWqtb6oKXteD8OqdgwlEtHQMQgrZlOZNKz/610+AXTqU1LuN9hkRpUQDIdNg4v/Mz6x/DM8LiTcoyn3ySq3dh1VsQniHwJDn++W/LUDaqU9PadsZabsz8RVyPj4r3aQlla/jSgC7ZClHM+RfqSg/5+l+aDRz/5sIoy2MhArE3K0Ei+ylUYwriNnZGkzBMd7aq4rVrCvMKfF6a+EH/nNg3fP1PZKH1DU7FIAZNaTe/Yd06CQkoknEGqIOAKbfgYwotR7nDfzy507AlQ7iHGQ+hs5V26tkmAimw9otlv1DjWdn7T5At5P5u4CvtI12auQTKaQtezkgcC8Z5a7zDBD4sJgMfQ+r3eyLj42v6wP1iGqsIl5nghbBWoyaJRooBhhyHG8tDbNmFCo5YIk6BYN6I0Mxe31DHrFP95DlDePWTGGBBkm8esfKrEiAQUJh2RPUv78YcTcwDh+2YXqxk4oR7IcOHxkROMPmf9SCoH79AzBjGuxhzP2gtruvgjqty4h9h47xTr9gdVLZU0LsWAsVhnlxcEth8xqpDzlU=
+cache:
+  yarn: true
+  directories:
+  - node_modules
+before_install:
+- yarn add git-directory-deploy
+script:
+- ./fetch.sh
+- ./build.sh
+after_success:
+- ./deploy.sh

--- a/build.sh
+++ b/build.sh
@@ -1,6 +1,8 @@
 #!/bin/bash
+
 rm -rf docs/*
 cp index.html docs/
+
 mkdocs build -f mkdocs.yml
 mkdocs build -f mkdocs_fr.yml
 msgmerge --update i18n/fr_FR/LC_MESSAGES/messages.po i18n/messages.pot

--- a/deploy.sh
+++ b/deploy.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+if [[ "$TRAVIS_BRANCH" != "master" ]]; then
+    echo "Not on master (branch is $TRAVIS_BRANCH), aborting deploy"
+    exit 0
+fi
+
+if [[ "$TRAVIS_PULL_REQUEST" != "false" ]]; then
+    echo "On pull request, aborting deploy"
+    exit 0
+fi
+
+if [[ "$GITHUB_TOKEN" == "" ]]; then
+    echo "No GitHub token, aborting deploy"
+    exit 0
+fi
+
+yarn git-directory-deploy \
+    --username Cozy \
+    --email contact@cozycloud.cc \
+    --directory docs/ \
+    --repo=https://$GITHUB_TOKEN@github.com/cozy/cozy-collect.git \
+    --branch=build

--- a/fetch.sh
+++ b/fetch.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+
+function fetch-from-remote {
+    repo=$1
+    dir=$2
+    if [[ ! -d "$dir" ]]; then
+        echo "mkdir $dir"
+        mkdir -p "$dir"
+    fi
+    echo "Going to $2"
+    cd $dir
+    if [[ -e .git ]]; then
+        git pull
+    else
+        git clone $repo --depth 1 .
+    fi
+    cd -
+}
+
+fetch-from-remote https://github.com/cozy/cozy-konnector-libs.git /tmp/cozy-konnector-libs
+ln -s /tmp/cozy-konnector-libs/packages/cozy-konnector-libs/docs src/cozy-konnector-libs
+
+fetch-from-remote https://github.com/cozy/cozy-client-js.git /tmp/cozy-client-js
+ln -s /tmp/cozy-client-js/docs src/cozy-client-js

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -30,6 +30,26 @@ pages:
     - "Develop a connector": dev/konnector.md
     - "Create a mobile app with cordova": dev/cordova.md
     - "How to send mail in development": dev/sendmail.md
+  - References:
+    - cozy-konnector-libs:
+      - "API" : cozy-konnector-libs/api.md
+      - "CLI": cozy-konnector-libs/cli.md
+      - "Develop": cozy-konnector-libs/dev.md
+      - "Errors": cozy-konnector-libs/errors.md
+      - "Operation linking": cozy-konnector-libs/operation-linking.md
+      - "Synchronization": cozy-konnector-libs/synchronization.md
+    - cozy-client-js:
+      - "Introduction": cozy-client-js/intro.md
+      - "Transition from cozy-browser-sdk": cozy-client-js/browser-sdk-transition.md
+      - "How to support offline": cozy-client-js/offline.md
+      - "OAuth guide": cozy-client-js/oauth.md
+      - "Authentication API": cozy-client-js/auth-api.md
+      - "Data System API": cozy-client-js/data-api.md
+      - "Files API": cozy-client-js/files-api.md
+      - "Jobs API": cozy-client-js/jobs-api.md
+      - "Intents API": cozy-client-js/intents-api.md
+      - "Settings API": cozy-client-js/settings-api.md
+      - "Sharing API": cozy-client-js/sharing-api.md
 theme: mkdocs
 theme_dir: 'cozy-theme'
 markdown_extensions:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+mkdocs
+markdown-i18n
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,2 @@
 mkdocs
 markdown-i18n
-


### PR DESCRIPTION
Include docs from other repositories in a reference tab.

* `./fetch.sh` clones other repositories in /tmp and adds symbolic
links into `src`
* `cozy-client-js`
* `cozy-konnector-libs`