### PR TITLE
added installation of apt-transport-https for debian

### DIFF
--- a/src/install/debian.md
+++ b/src/install/debian.md
@@ -71,6 +71,11 @@ curl https://apt.cozy.io/nightly/cozy.gpg | \
     apt-key --keyring /etc/apt/trusted.gpg.d/cozy.gpg add -
 ```
 
+finally, ensure that apt is able to use https repositories:
+
+```bash
+apt install ca-certificates apt-transport-https
+```
 
 ## Setup
 
@@ -88,13 +93,13 @@ Install CouchDB in `standalone` mode
 
 Configure CouchDB to listen on `127.0.0.1`
 
-Pick an administrator password  
+Pick an administrator password
 (This password is used by shell scripts, so currently avoid to use one with simple or double quotes or others shell meaningfull symbols. We advice you to choose one with only alphanumeric digits to avoid troubles.)
 
 At this point, you must have a working CouchDB instance
 
 ```bash
-curl http://localhost:5984/       
+curl http://localhost:5984/
 {"couchdb":"Welcome","version":"2.1.0","features":["scheduler"],"vendor":{"name":"The Apache Software Foundation"}}
 ```
 
@@ -115,7 +120,7 @@ Cozy need to create a CouchDB administrator and so to connect as admin to the Co
 
  (Those passwords are used by shell scripts, so currently avoid to use ones with simple or double quotes or others shell meaningfull symbols. We advice you to choose ones with only alphanumeric digits to avoid troubles.)
 
-For stack management (create instances, install applications...), [Cozy need an administrator password](https://github.com/cozy/cozy-stack/blob/2ae446d85b60c89fb56cad1f7ed469cddca94494/docs/config.md#user-content-administration-secret). So pick a new one.  
+For stack management (create instances, install applications...), [Cozy need an administrator password](https://github.com/cozy/cozy-stack/blob/2ae446d85b60c89fb56cad1f7ed469cddca94494/docs/config.md#user-content-administration-secret). So pick a new one.
 When invoking `cozy-stack` (or `cozy-coclyco` which use it under the hood), you need to set the `COZY_ADMIN_PASSWORD` environment variable with this password. You can put it on your `.bashrc` for simplier life if you want.
 
 At this point, you must have a working Cozy stack
@@ -133,7 +138,7 @@ If you want to use konnectors, you need to initialize the NodeJS chroot
 /usr/share/cozy/konnector-create-chroot.sh
 ```
 
-If you use a self-signed certificate or a not official certificate authority, you need to deploy the corresponding root certificate in `/usr/share/cozy/chroot/etc/ssl/certs/custom.crt`.  
+If you use a self-signed certificate or a not official certificate authority, you need to deploy the corresponding root certificate in `/usr/share/cozy/chroot/etc/ssl/certs/custom.crt`.
 For example, if you use [Let's Encrypt staging environment](https://letsencrypt.org/docs/staging-environment/) for testing purpose :
 
 ```bash

--- a/src/install/debian.md
+++ b/src/install/debian.md
@@ -39,6 +39,13 @@ curl https://apt.cozy.io/nightly/cozy.gpg | \
     apt-key --keyring /etc/apt/trusted.gpg.d/cozy.gpg add -
 ```
 
+Ensure that apt is able to use https repositories:
+
+```bash
+apt install ca-certificates apt-transport-https
+```
+
+
 Then, setup your repository. Select the channel that best fit your needs:
 
 !!! warning ""
@@ -59,6 +66,10 @@ Supported repositories are:
      * deb https://apt.cozy.io/raspbian/ stretch testing
      * deb https://apt.cozy.io/nightly/raspbian/ stretch unstable
 
+
+
+
+
 ```bash
 echo "deb https://apt.cozy.io/debian/ stretch stable" > /etc/apt/sources.list.d/cozy.list
 apt update
@@ -71,11 +82,7 @@ curl https://apt.cozy.io/nightly/cozy.gpg | \
     apt-key --keyring /etc/apt/trusted.gpg.d/cozy.gpg add -
 ```
 
-finally, ensure that apt is able to use https repositories:
 
-```bash
-apt install ca-certificates apt-transport-https
-```
 
 ## Setup
 

--- a/src/install/debian.md
+++ b/src/install/debian.md
@@ -30,7 +30,14 @@ Like CouchDB, you can choose to install your reverse proxy on the same host, or 
 
 ## Prerequisites
 
-First, you need to fetch the GPG Cozy signing key:
+First, install the packages required to install cozy
+
+```bash
+apt install ca-certificates apt-transport-https curl
+```
+
+
+Then, fetch the GPG Cozy signing key:
 
 ```bash
 curl https://apt.cozy.io/cozy.gpg | \
@@ -39,14 +46,10 @@ curl https://apt.cozy.io/nightly/cozy.gpg | \
     apt-key --keyring /etc/apt/trusted.gpg.d/cozy.gpg add -
 ```
 
-Ensure that apt is able to use https repositories:
-
-```bash
-apt install ca-certificates apt-transport-https
-```
 
 
-Then, setup your repository. Select the channel that best fit your needs:
+
+Finally, setup your repository. Select the channel that best fit your needs:
 
 !!! warning ""
     ⚠️ For now, packages are only available in `testing` and `unstable` channels. Adapt your `sources.list` accordingly.


### PR DESCRIPTION
Hi, 
While trying to install cozy on a debian LXC container, I discovered that the packages `ca-certificates` and `apt-transport-https` were not installed on my default container image.

Without these, apt is unable to fetch the cozy repos and download the packages

It is a well documented issue, but I added them to the docs' prerequisites to ease installation for beginners.