### PR TITLE
feat: auto table of contents

### DIFF
--- a/OUTSIDE_DOCS
+++ b/OUTSIDE_DOCS
@@ -1,0 +1,3 @@
+cozy-client-js https://github.com/cozy/cozy-client-js.git docs
+cozy-konnector-libs https://github.com/cozy/cozy-konnector-libs.git packages/cozy-konnector-libs/docs
+cozy-doctypes https://github.com/cozy/cozy-doctypes.git .

--- a/add_outside_docs.py
+++ b/add_outside_docs.py
@@ -1,0 +1,63 @@
+import yaml
+import json
+import os
+import sys
+import re
+import os.path as osp
+from collections import OrderedDict
+
+def ordered_load(stream, Loader=yaml.Loader, object_pairs_hook=OrderedDict):
+    class OrderedLoader(Loader):
+        pass
+    def construct_mapping(loader, node):
+        loader.flatten_mapping(node)
+        return object_pairs_hook(loader.construct_pairs(node))
+    OrderedLoader.add_constructor(
+        yaml.resolver.BaseResolver.DEFAULT_MAPPING_TAG,
+        construct_mapping)
+    return yaml.load(stream, OrderedLoader)
+
+
+def ordered_dump(data, stream=None, Dumper=yaml.Dumper, **kwds):
+    class OrderedDumper(Dumper):
+        pass
+    def _dict_representer(dumper, data):
+        return dumper.represent_mapping(
+            yaml.resolver.BaseResolver.DEFAULT_MAPPING_TAG,
+            data.items())
+    OrderedDumper.add_representer(OrderedDict, _dict_representer)
+    return yaml.dump(data, stream, OrderedDumper, **kwds)
+
+
+leadingHash = re.compile('#+\s+')
+
+def read_toc(directory):
+    toc_path = osp.join('src', directory, 'toc.yml')
+    if not osp.exists(toc_path):
+        return
+    else:
+        with open(toc_path) as f:
+            toc = ordered_load(f)
+            for ref in toc:
+                for k in ref.iterkeys():
+                    ref[k] = re.sub('^.', directory, ref[k])
+            return toc
+
+def main():
+    with open('./mkdocs.yml') as f:
+        data = ordered_load(f, yaml.SafeLoader)
+
+    with open('OUTSIDE_DOCS') as f:
+        outside_docs = [l.split(' ')[0] for l in f.readlines()]
+
+    references = [p for p in data['pages'] if p.get('References')][0]['References']
+    del references[:]
+
+    for dir in outside_docs:
+        abs = osp.join('./src', dir)
+        toc = read_toc(dir)
+        if toc:
+            references.append({ dir: toc })
+
+    with open('mkdocs.yml', 'w+') as f:
+        ordered_dump(data, f, indent=2, default_flow_style=False, Dumper=yaml.SafeDumper)

--- a/fetch.sh
+++ b/fetch.sh
@@ -17,8 +17,15 @@ function fetch-from-remote {
     cd -
 }
 
-fetch-from-remote https://github.com/cozy/cozy-konnector-libs.git /tmp/cozy-konnector-libs
-ln -s /tmp/cozy-konnector-libs/packages/cozy-konnector-libs/docs src/cozy-konnector-libs
-
-fetch-from-remote https://github.com/cozy/cozy-client-js.git /tmp/cozy-client-js
-ln -s /tmp/cozy-client-js/docs src/cozy-client-js
+cat OUTSIDE_DOCS | while read line; do
+  arr=($line)
+  name=${arr[0]}
+  repo=${arr[1]}
+  subdir=${arr[2]}
+  tmpsubdir="/tmp/$name"
+  if [[ $subdir != "." ]]; then
+    tmpsubdir=${tmpsubdir}/${subdir}
+  fi
+  fetch-from-remote $repo /tmp/$name
+  ln -s /tmp/$name/$subdir src/$name
+done

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -7,60 +7,48 @@ repo_url: https://github.com/cozy/cozy-docs-v3
 edit_uri: edit/master/src/
 site_description: Cozy documentation
 site_author: CozyCloud - https://cozy.io
-extra_css: [css/extra.css, css/highlight_theme.css]
-extra_javascript: [extra.js]
+extra_css:
+- css/extra.css
+- css/highlight_theme.css
+extra_javascript:
+- extra.js
 pages:
-  - Home: index.md
-  - Use:
-    - "User guide": use/index.md
-  - Synchronize:
-    - 'Stay in sync': sync/index.md
-    - 'Synchronize your phone': sync/phone.md
-    - 'Synchronize your computer': sync/desktop.md
-    - 'Install on GNU/Linux': sync/linux.md
-  - Download: download/index.md
-  - Install:
-    - install/index.md
-    - "Debian": install/debian.md
-    - "Manual installation": install/manual.md
-  - Develop:
-    - "Let's hack some code": dev/index.md
-    - "Architecture": dev/intro.md
-    - "Create your first app": dev/app.md
-    - "Develop a connector": dev/konnector.md
-    - "Create a mobile app with cordova": dev/cordova.md
-    - "How to send mail in development": dev/sendmail.md
-  - References:
-    - cozy-konnector-libs:
-      - "API" : cozy-konnector-libs/api.md
-      - "CLI": cozy-konnector-libs/cli.md
-      - "Develop": cozy-konnector-libs/dev.md
-      - "Errors": cozy-konnector-libs/errors.md
-      - "Operation linking": cozy-konnector-libs/operation-linking.md
-      - "Synchronization": cozy-konnector-libs/synchronization.md
-    - cozy-client-js:
-      - "Introduction": cozy-client-js/intro.md
-      - "Transition from cozy-browser-sdk": cozy-client-js/browser-sdk-transition.md
-      - "How to support offline": cozy-client-js/offline.md
-      - "OAuth guide": cozy-client-js/oauth.md
-      - "Authentication API": cozy-client-js/auth-api.md
-      - "Data System API": cozy-client-js/data-api.md
-      - "Files API": cozy-client-js/files-api.md
-      - "Jobs API": cozy-client-js/jobs-api.md
-      - "Intents API": cozy-client-js/intents-api.md
-      - "Settings API": cozy-client-js/settings-api.md
-      - "Sharing API": cozy-client-js/sharing-api.md
+- Home: index.md
+- Use:
+  - User guide: use/index.md
+- Synchronize:
+  - Stay in sync: sync/index.md
+  - Synchronize your phone: sync/phone.md
+  - Synchronize your computer: sync/desktop.md
+  - Install on GNU/Linux: sync/linux.md
+- Download: download/index.md
+- Install:
+  - install/index.md
+  - Debian: install/debian.md
+  - Manual installation: install/manual.md
+- Develop:
+  - Let's hack some code: dev/index.md
+  - Architecture: dev/intro.md
+  - Create your first app: dev/app.md
+  - Develop a connector: dev/konnector.md
+  - Create a mobile app with cordova: dev/cordova.md
+  - How to send mail in development: dev/sendmail.md
+- References:
+  - cozy-konnector-libs:
+    - API: cozy-konnector-libs/api.md
+    - CLI: cozy-konnector-libs/cli.md
+    - Develop: cozy-konnector-libs/dev.md
+    - Errors: cozy-konnector-libs/errors.md
+    - Operation linking: cozy-konnector-libs/operation-linking.md
+    - Synchronization: cozy-konnector-libs/synchronization.md
 theme: mkdocs
-theme_dir: 'cozy-theme'
+theme_dir: cozy-theme
 markdown_extensions:
-  - admonition
-  - codehilite
-  - extra
-  - footnotes
-  #- markdown_i18n:
-  #    i18n_lang: en_US
-  #    i18n_dir: i18n
-  - sane_lists
-  - smarty
-  - toc:
-      permalink: True
+- admonition
+- codehilite
+- extra
+- footnotes
+- sane_lists
+- smarty
+- toc:
+    permalink: true

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 mkdocs
 markdown-i18n
+pyyaml


### PR DESCRIPTION
The idea is that it is the outside doc that best knows its table of contents
so it should be configured there.

Here we use a special `toc.yml` file from the outside documentation and include
it in the References directly. I added a toc file in `cozy-konnector-libs` as an
example : https://github.com/cozy/cozy-konnector-libs/blob/master/packages/cozy-konnector-libs/docs/toc.yml

Also, `fetch.sh` now reads from a file for the configuration of outside documentation.
It decouples code from config.